### PR TITLE
Fix: Prevent view update conflict on navigation

### DIFF
--- a/PicEase/ControlBarView.swift
+++ b/PicEase/ControlBarView.swift
@@ -77,8 +77,11 @@ struct ControlBarView: View {
         Button(action: {
             // 新しいインデックスを計算。0未満や総数以上にならないようにクランプ（範囲内に収める）。
             let newIndex = min(max(0, controller.selectedIndex + offset), controller.imagePaths.count - 1)
-            // 計算した新しいインデックスをコントローラに設定
-            controller.selectedIndex = newIndex
+            // 状態の更新をメインスレッドで非同期に実行し、UI更新の競合を防ぐ
+            DispatchQueue.main.async {
+                // 計算した新しいインデックスをコントローラに設定
+                controller.selectedIndex = newIndex
+            }
         }) {
             // ボタンの見た目（アイコン）
             Image(systemName: systemName)


### PR DESCRIPTION
Wrapped the `selectedIndex` update in the `moveButton` action within a `DispatchQueue.main.async` block.

This resolves a 'Publishing changes from within view updates is not allowed' error that occurred when navigating images while the thumbnail view was visible. The asynchronous dispatch prevents the state update from conflicting with the view update cycle triggered by the button press and the subsequent scroll action in the thumbnail view.